### PR TITLE
Improve ARM64 dependency docs and pyenv setup

### DIFF
--- a/PERFORMANCE_OPTIMIZATION_SUMMARY.md
+++ b/PERFORMANCE_OPTIMIZATION_SUMMARY.md
@@ -80,6 +80,11 @@ Comprehensive performance optimization implementation for LawnBerryPi on Raspber
 - Memory usage: <6GB with controlled growth
 - Vision FPS: 30 FPS sustained (50% improvement)
 
+## Model Resource Planning
+Heavy machine learning libraries such as `numpy` and `scikit-learn` can saturate Raspberry Pi 4
+resources. Evaluate models on target hardware and consider off-device training or lighter
+architectures when real-time performance cannot be met.
+
 ## Implementation Files
 
 ### Core Optimization Scripts

--- a/requirements-README.md
+++ b/requirements-README.md
@@ -40,6 +40,15 @@ sudo apt-get install python3-pycoral python3-tflite-runtime
 pip install -r requirements-optional.txt
 ```
 
+#### Verifying ARM64 Wheels
+Some heavy dependencies such as `opencv-python`, `scikit-learn`, and `pandas` require ARM64 wheels on Raspberry Pi.
+If a prebuilt wheel is unavailable, compile from source using `pip wheel` with the `--no-binary=:all:` option or
+install via the `piwheels.org` index:
+
+```bash
+pip install --extra-index-url https://www.piwheels.org/simple opencv-python scikit-learn pandas
+```
+
 ### Development Installation
 ```bash
 # Install all dependencies for development
@@ -77,6 +86,10 @@ pip install -r requirements-coral.txt
 ### Coral Installation Issues
 - **Problem**: pip installation fails for pycoral on Python 3.11+
 - **Solution**: Use system packages: `sudo apt-get install python3-pycoral`
+
+### TensorFlow Lite Runtime
+- **Problem**: `tflite-runtime` wheels are only published for ARM64 Linux and specific Python versions.
+- **Solution**: Ensure the target is Raspberry Pi OS 64-bit. On other platforms the package is skipped.
 
 ### Missing Hardware Packages
 - **Problem**: Hardware-specific imports fail

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ aiomqtt>=2.1.0,<3.0.0
 # Computer Vision System Dependencies - Bookworm optimized
 opencv-python>=4.8.0,<5.0.0
 numpy>=1.21.0,<2.0.0
-tflite-runtime>=2.13.0,<3.0.0; sys_platform == "linux"
+# TensorFlow Lite runtime is only available on ARM64 Linux
+tflite-runtime>=2.13.0,<3.0.0; sys_platform == "linux" and platform_machine == "aarch64"
 pillow>=9.0.0,<11.0.0
 scikit-image>=0.19.0,<1.0.0
 scikit-learn>=1.3.0,<2.0.0

--- a/scripts/install_lawnberry.sh
+++ b/scripts/install_lawnberry.sh
@@ -646,8 +646,20 @@ setup_coral_packages() {
 
     export PYENV_ROOT="$HOME/.pyenv"
     export PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init -)" 2>/dev/null || true
-    eval "$(pyenv virtualenv-init -)" 2>/dev/null || true
+
+    if ! command -v pyenv >/dev/null 2>&1; then
+        log_info "pyenv not found, installing..."
+        curl https://pyenv.run | bash
+        export PATH="$PYENV_ROOT/bin:$PATH"
+    fi
+
+    if command -v pyenv >/dev/null 2>&1; then
+        eval "$(pyenv init -)" 2>/dev/null || true
+        eval "$(pyenv virtualenv-init -)" 2>/dev/null || true
+    else
+        log_error "pyenv installation failed"
+        exit 1
+    fi
 
     if ! pyenv versions | grep -q "$PYTHON_39_VERSION"; then
         log_info "Installing Python $PYTHON_39_VERSION via pyenv..."
@@ -713,6 +725,10 @@ setup_coral_packages() {
     log_info "Creating helper script to activate Coral environment..."
     cat > "$PROJECT_ROOT/activate_coral.sh" << EOF
 #!/bin/bash
+if ! command -v pyenv >/dev/null 2>&1; then
+  echo "pyenv is required but not installed." >&2
+  exit 1
+fi
 export PYENV_ROOT="\$HOME/.pyenv"
 export PATH="\$PYENV_ROOT/bin:\$PATH"
 eval "\$(pyenv init -)"


### PR DESCRIPTION
## Summary
- restrict tflite-runtime to ARM64 platforms
- document ARM64 wheel handling and TensorFlow Lite runtime limitations
- add model resource planning guidance
- ensure install script installs pyenv when missing and checks in activation script

## Testing
- `pre-commit run --all-files`
- `python -m pytest tests/ --cov=src --cov-report=html -v` *(fails: cannot import MimeMultipart)*

------
https://chatgpt.com/codex/tasks/task_e_689e40fe40108322bf33fa5b41a6641b