### PR TITLE
fix: enable live sensor pipeline and camera access

### DIFF
--- a/src/hardware/sensor_service.py
+++ b/src/hardware/sensor_service.py
@@ -108,6 +108,9 @@ class SensorService:
             # Initialize hardware interface with explicit absolute config path to avoid
             # WorkingDirectory pitfalls under systemd. Prefer PYTHONPATH hint (set to /opt/lawnberry).
             import os
+            os.environ.setdefault('LAWNBERY_DISABLE_CAMERA', '1')
+            if os.environ.get('LAWNBERY_DISABLE_CAMERA') == '1':
+                self.logger.info('Camera disabled for sensor service to avoid device contention')
             repo_root = os.environ.get('PYTHONPATH', '/opt/lawnberry').split(os.pathsep)[0]
             cfg_path = str(Path(repo_root) / 'config' / 'hardware.yaml')
             self.logger.info(f"Creating hardware interface with config: {cfg_path}")


### PR DESCRIPTION
## Summary
- support MQTT wildcard handlers so WebSocket clients receive live sensor data
- prevent sensor service from grabbing camera to allow web API video stream

## Testing
- `pytest tests/test_sensor_service_formatting.py tests/test_communication_system.py -k "" -v` *(fails: ModuleNotFoundError: No module named 'paho')*
- `pre-commit run --files src/web_api/mqtt_bridge.py src/hardware/sensor_service.py` *(fails: flake8 missing docstrings, mypy module mapping, bandit missing pbr)*

------
https://chatgpt.com/codex/tasks/task_e_68baffe112988322ab815cbc2cd21c63