### PR TITLE
Update dependency versions for Raspberry Pi compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,54 +6,54 @@
 # See requirements-coral.txt for pip-based fallback installation if system packages fail.
 
 # Data Management System Dependencies
-redis>=4.5.0,<6.0.0
-aiosqlite>=0.19.0,<1.0.0
-sqlalchemy>=2.0.0,<3.0.0
-pyyaml>=6.0,<7.0.0
-aiomqtt>=2.1.0,<3.0.0
-paho-mqtt>=2.0.0,<3.0.0
+redis>=6.4.0,<7.0.0
+aiosqlite>=0.21.0,<1.0.0
+sqlalchemy>=2.0.43,<3.0.0
+pyyaml>=6.0.2,<7.0.0
+aiomqtt>=2.4.0,<3.0.0
+paho-mqtt>=2.1.0,<3.0.0
 
 # Computer Vision System Dependencies - Bookworm optimized
-opencv-python>=4.8.0,<5.0.0
-numpy>=1.21.0,<2.0.0
+opencv-python>=4.12.0.88,<5.0.0
+numpy>=2.3.2,<3.0.0
 # TensorFlow Lite runtime is only available on ARM64 Linux
-tflite-runtime>=2.13.0,<3.0.0; sys_platform == "linux" and platform_machine == "aarch64"
-pillow>=9.0.0,<11.0.0
-scikit-image>=0.19.0,<1.0.0
-scikit-learn>=1.3.0,<2.0.0
-pandas>=1.5.0,<3.0.0
+tflite-runtime>=2.14.0,<3.0.0; sys_platform == "linux" and platform_machine == "aarch64"
+pillow>=11.3.0,<12.0.0
+scikit-image>=0.25.2,<1.0.0
+scikit-learn>=1.7.2,<2.0.0
+pandas>=2.3.2,<3.0.0
 
 # Hardware interface dependencies - Pi 4B/5 compatible
 pyserial>=3.5,<4.0.0
-lgpio>=0.2.2,<1.0.0; sys_platform == "linux"
-gpiozero>=1.6.2,<2.0.0; sys_platform == "linux"
-smbus2>=0.4.0,<1.0.0; sys_platform == "linux"
+lgpio>=0.2.2.0,<1.0.0; sys_platform == "linux"
+gpiozero>=2.0.1,<3.0.0; sys_platform == "linux"
+smbus2>=0.5.0,<1.0.0; sys_platform == "linux"
 
 # I2C and sensor libraries for Bookworm
-Adafruit-Blinka>=8.29.0; sys_platform == "linux"
-adafruit-circuitpython-bme280; sys_platform == "linux"
-adafruit-circuitpython-vl53l0x>=3.6.0,<4.0.0; sys_platform == "linux"
-adafruit-circuitpython-ssd1306>=2.12.14,<3.0.0; sys_platform == "linux"
-adafruit-circuitpython-ina219>=3.4.0,<4.0.0; sys_platform == "linux"
-adafruit-circuitpython-bno08x>=1.2.0; sys_platform == "linux"
+Adafruit-Blinka>=8.66.0; sys_platform == "linux"
+adafruit-circuitpython-bme280>=2.6.29,<3.0.0; sys_platform == "linux"
+adafruit-circuitpython-vl53l0x>=3.6.16,<4.0.0; sys_platform == "linux"
+adafruit-circuitpython-ssd1306>=2.12.21,<3.0.0; sys_platform == "linux"
+adafruit-circuitpython-ina219>=3.4.29,<4.0.0; sys_platform == "linux"
+adafruit-circuitpython-bno08x>=1.2.10,<2.0.0; sys_platform == "linux"
 
 # Web API Backend Dependencies
-fastapi>=0.104.0,<1.0.0
-uvicorn[standard]>=0.24.0,<1.0.0
-pydantic>=2.5.0,<3.0.0
-pydantic-settings>=2.0.0,<3.0.0
-python-jose[cryptography]>=3.3.0,<4.0.0
+fastapi>=0.116.1,<1.0.0
+uvicorn[standard]>=0.35.0,<1.0.0
+pydantic>=2.11.7,<3.0.0
+pydantic-settings>=2.10.1,<3.0.0
+python-jose[cryptography]>=3.5.0,<4.0.0
 passlib[bcrypt]<2.0.0,>=1.7.4
 # Pin bcrypt to 4.0.1 for compatibility (passlib 1.7.4 expects __about__.__version__ present)
 bcrypt==4.0.1
-python-multipart<1.0.0,>=0.0.6
-websockets>=12.0,<13.0.0
-psutil>=5.9.0,<6.0.0
-python-dotenv>=1.0.0,<2.0.0
-aiohttp>=3.8.0,<4.0.0
-requests
-aiofiles>=23.2.1,<24.0.0
+python-multipart>=0.0.20,<1.0.0
+websockets>=15.0.1,<16.0.0
+psutil>=7.0.0,<8.0.0
+python-dotenv>=1.1.1,<2.0.0
+aiohttp>=3.12.15,<4.0.0
+requests>=2.32.5,<3.0.0
+aiofiles>=24.1.0,<25.0.0
 
 # Raspberry Pi specific dependencies
-picamera2>=0.3.12,<1.0.0; sys_platform == "linux"
+picamera2>=0.3.30,<1.0.0; sys_platform == "linux"
 pigpio>=1.78,<2.0.0; sys_platform == "linux"


### PR DESCRIPTION
## Summary
- update requirements to latest compatible versions for Raspberry Pi OS Bookworm

## Testing
- `python -m pre_commit run --all-files` *(fails: hook id: black)*
- `python -m pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'coverage', board, numpy, psutil, fastapi, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0472d5244832291ee88c7c600d072