### PR TITLE
feat(observability): baseline navigation tick runtime metric (§12)

### DIFF
--- a/backend/src/services/navigation_service.py
+++ b/backend/src/services/navigation_service.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from ..core.config_loader import ConfigLoader
+from ..core.observability import observability
 from ..models import (
     NavigationMode,
     NavigationState,
@@ -1160,7 +1161,20 @@ class NavigationService:
         self.navigation_state.heading = heading
 
     async def update_navigation_state(self, sensor_data: SensorData) -> NavigationState:
-        """Update navigation state with sensor fusion"""
+        """Update navigation state with sensor fusion.
+
+        Wall-time of the tick is recorded as the ``navigation_tick_duration``
+        timer metric (§12 runtime budget baseline).
+        """
+        start = time.perf_counter()
+        try:
+            return await self._update_navigation_state_impl(sensor_data)
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000.0
+            observability.metrics.record_timer("navigation_tick_duration", duration_ms)
+
+    async def _update_navigation_state_impl(self, sensor_data: SensorData) -> NavigationState:
+        """Original update_navigation_state body — measured by the public wrapper."""
 
         # Update position from GPS or dead reckoning
         current_position = await self._update_position(sensor_data)

--- a/docs/runtime-budget.md
+++ b/docs/runtime-budget.md
@@ -1,0 +1,56 @@
+# Runtime Budget — Navigation Tick
+
+This document tracks the runtime cost of the navigation tick (`NavigationService.update_navigation_state`) so we can detect regressions as the architecture plan progresses (§3 real-pose pipeline, §1 RuntimeContext follow-ups, §9 event persistence).
+
+The metric is the first deliverable of §12 ("Power, Thermal, and Runtime Budget") in `docs/major-architecture-and-code-improvement-plan.md`.
+
+## What is measured
+
+- **Series name:** `lawnberry_timer_navigation_tick_duration` (Prometheus-compatible).
+- **Sub-series:** `_count` (number of ticks), `_avg_ms`, `_min_ms`, `_max_ms`.
+- **Unit:** milliseconds of wall-clock time per call.
+- **Scope:** entire body of `NavigationService.update_navigation_state` — pose update from GPS/dead-reckoning, heading fusion (IMU + GPS COG), obstacle detection, navigation-state mutation. Does not include `set_speed` or motor command delivery (those are outside the tick).
+
+## How to read the current value
+
+Run the backend and curl the metrics endpoint:
+
+```bash
+curl -s http://localhost:8000/metrics | grep navigation_tick_duration
+```
+
+Expected output shape:
+
+```text
+lawnberry_timer_navigation_tick_duration_count 1234
+lawnberry_timer_navigation_tick_duration_avg_ms 4.21
+lawnberry_timer_navigation_tick_duration_min_ms 0.83
+lawnberry_timer_navigation_tick_duration_max_ms 18.07
+```
+
+## How to capture a baseline
+
+A baseline pair `(avg_ms, max_ms)` should be captured on the target Pi 5 platform before each major architecture change, and committed to this doc with the date and HEAD SHA.
+
+1. Boot the mower in `SIM_MODE=0` (real hardware) with a typical mission running.
+2. Let the mission run for **at least 5 minutes** so the timer averages stabilize across waypoints, tank turns, and obstacle events.
+3. Capture the metric once: `curl -s http://localhost:8000/metrics | grep navigation_tick_duration`.
+4. Append a row to the baseline table below.
+
+## Baseline history
+
+| Date | HEAD SHA | Conditions | count | avg_ms | min_ms | max_ms | Notes |
+|------|----------|------------|-------|--------|--------|--------|-------|
+| _TBD — first capture pending operator yard run_ | | | | | | | Captured before §3 real-pose pipeline |
+
+## Regression policy
+
+- A change that increases `avg_ms` by more than 50% over the previous baseline must justify the cost in the PR description.
+- A change that increases `max_ms` by more than 100% (a new tail latency spike) must include a follow-up issue or a mitigation note in the same PR.
+- These thresholds are intentionally loose for the first two captured baselines while we learn the variance of the metric on real hardware. Tighten in a follow-up once we have ≥3 baseline rows.
+
+## Related code
+
+- Instrumentation: `backend/src/services/navigation_service.py` — the `update_navigation_state` wrapper.
+- Endpoint: `backend/src/api/metrics.py` — Prometheus-compatible serializer.
+- Plan reference: `docs/major-architecture-and-code-improvement-plan.md` §12.

--- a/docs/session-handoff-2026-04-29.md
+++ b/docs/session-handoff-2026-04-29.md
@@ -1,0 +1,81 @@
+# Session Handoff — 2026-04-29
+
+**Branch:** `main`
+**HEAD:** `3df96a9` (chore(ci): stabilize three persistently-red PR checks (#46))
+**Working tree:** clean (only `.claude/` untracked — local Claude Code state, not session debris)
+**CI on `main`:** all checks green
+**Tests:** `SIM_MODE=1 uv run pytest -q` → 600 passed, 47 skipped, 12 xfailed, 2 xpassed
+
+---
+
+## What this session shipped
+
+Two PRs merged into `main`:
+
+| PR | Scope | Plan doc |
+|----|-------|----------|
+| **#45** | §1 typed `RuntimeContext` for safety-critical routers (safety + mission migrated; rest.py deferred to §4) | `docs/superpowers/plans/2026-04-26-runtime-context.md` |
+| **#46** | CI stabilization — three persistently-red PR checks (`pr-hygiene`, `config-lint`, `webui-build`) reduced to mechanical fixes | _(no plan doc; one-shot infra fix)_ |
+
+Earlier in the rolling effort (already merged before this session): §8 replay harness (plan `2026-04-26-replay-harness.md`).
+
+---
+
+## Architecture plan reference
+
+The active backlog lives in `docs/major-architecture-and-code-improvement-plan.md`. Done so far:
+
+- §1 RuntimeContext ✅
+- §8 Replay harness ✅
+- §10 Lint ratchet (E501/E402/B008 globally ignored, F811 per-file) ✅
+
+Phase 1 still open: §3, §4, §6, §11, §12 (and §1 follow-ups below).
+
+---
+
+## Top priorities for the next session
+
+In recommended order (small wins first, then the substantial piece):
+
+### 1. §12 — Baseline runtime budget metrics _(small, ~1 PR)_
+Add a Prometheus-or-stdlib counter that tracks per-loop wall time for the navigation tick. Plan §12 has the spec. Goal: a baseline number we can regression-test against once §3 (real pose pipeline) lands.
+
+### 2. §1 follow-up: `runtime.sensor_manager` live reference _(small, ~1 PR)_
+Currently `RuntimeContext.sensor_manager` is captured at lifespan-construction time as a snapshot, and is typically `None` because sensor_manager is lazy-initialized later. Documented landmine in `docs/runtime-context.md` and `backend/src/main.py:184` (TODO referencing issue #44). Fix: convert the field to a property that delegates to `AppState.sensor_manager` so the live value is always read. **Do not migrate any router to read `runtime.sensor_manager` until this lands.**
+
+### 3. §4 + §11 — Motor command gateway _(substantial, multi-PR plan)_
+The natural seam for unifying emergency state ownership. Today `_safety_state`, `_blade_state`, `_emergency_until`, and `_client_emergency` are mutated bidirectionally across `rest.py` and `safety.py`. §4 introduces a typed motor command gateway that owns this state; §11 firms up the firmware contract. Touches: `backend/src/api/rest.py` (drive/emergency endpoints), `backend/src/services/robohat_service.py`, possibly a new `backend/src/services/motor_gateway.py`. **Use the brainstorming + writing-plans skills before coding.**
+
+### 4. Capture a real yard-run fixture _(operator task — not coding)_
+Set `LAWNBERRY_CAPTURE_PATH=data/captures/yard-$(date +%Y%m%d).jsonl`, drive the mower outside, and commit the JSONL. Exercises the §8 replay harness against real-world data and surfaces any drift between simulator and field telemetry. Operator confirm/disable steps are in `docs/diagnostics-replay.md`.
+
+---
+
+## Outstanding follow-ups (deferred / non-blocking)
+
+- **`webui-build` e2e tests** — dropped from CI in #46. Re-add in a dedicated workflow with `setup-uv`, `uv sync --frozen`, and a backend readiness wait. The `playwright.config.ts` `webServer` already starts vite preview on :4173, so the e2e step only needs uvicorn for tests that hit the API.
+- **`config-lint` systemd validation** — dropped from CI in #46. Re-add with a syntactic-only validator or with mocked path scaffolding (dummy `/home/pi/lawnberry/.venv/bin/uvicorn`, `/apps/lawnberry-pi/...`).
+- **`RuntimeContext` field types** — currently `Any` to avoid import cycles. Tighten when service modules split (Phase 2).
+- **`AppState` retirement** — explicit deferral. Don't touch until all consumers migrate.
+- **Pre-existing flaky test** — `tests/unit/test_navigation_service.py::test_execute_mission_waits_while_paused` timed out once during this session's regression sweep, passed on rerun. Tracked but not actioned.
+- **`xfail` markers** — 12 xfails on `main`; most are CI-only path issues (`/home/pi/lawnberry` hardcoded vs `/home/runner/work/...`). Cleanup is low priority.
+
+---
+
+## Landmines / non-obvious context
+
+- **Test isolation:** `NavigationService.get_instance()` is a singleton that leaks state across tests. `tests/conftest.py` has an autouse fixture that resets it. If you write a new test and see weird state-leak failures, check that fixture is firing.
+- **`app.dependency_overrides`:** Cleared by autouse `reset_app_state_runtime_and_overrides` fixture between tests. To inject a fake runtime, set `app.dependency_overrides[get_runtime] = lambda: fake_runtime` and the conftest will clean up.
+- **ASGITransport vs TestClient:** `httpx.ASGITransport(app=app)` does NOT run the lifespan; `app.state.runtime` will be `None`. Either use `TestClient(app)` (runs lifespan) or override `get_runtime` with a fixture (see `tests/integration/test_control_manual_flow.py` for the canonical pattern).
+- **Cross-router state:** When constructing a fake `RuntimeContext` for tests that exercise both legacy (`rest.py`) and migrated (`safety.py`) routers, point `safety_state` and `blade_state` at the **real `core.globals._safety_state`/`_blade_state` dicts** — the legacy router mutates those by name, so empty fakes break latching tests.
+- **`pyproject.toml` lockfile environments:** `tool.uv.environments` lists `aarch64`, `armv7l`, AND `x86_64` so CI (Intel Linux) can resolve the lockfile. Don't reintroduce the `x86_64` ban in `deps-lock.yml`.
+- **`ruff==0.13.3` is pinned** in `.github/workflows/ci.yml`. Bumping introduces UP042 and other new rule families that need a deliberate cleanup pass.
+
+---
+
+## Skills to use next session
+
+- `superpowers:brainstorming` before starting §4 (motor gateway design has tradeoffs worth exploring).
+- `superpowers:writing-plans` to write the §4 plan doc once the design is settled.
+- `superpowers:test-driven-development` for §12 (small enough to TDD cleanly).
+- `superpowers:verification-before-completion` before opening any PR.

--- a/docs/superpowers/plans/2026-04-29-navigation-tick-metric.md
+++ b/docs/superpowers/plans/2026-04-29-navigation-tick-metric.md
@@ -1,0 +1,291 @@
+# Navigation Tick Baseline Metric Implementation Plan (§12)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Instrument `NavigationService.update_navigation_state` to record per-call wall time as a timer metric so we have a baseline runtime number we can regression-test against once the §3 real-pose pipeline lands. Implements the first deliverable of §12 in `docs/major-architecture-and-code-improvement-plan.md` ("CPU per service under nominal mission load") for the navigation service.
+
+**Architecture:** The codebase already has an `observability` singleton in `backend/src/core/observability.py` that exposes `MetricsCollector.record_timer(name, duration_ms)`. The `/metrics` endpoint at `backend/src/api/metrics.py` already serializes timers as `lawnberry_timer_<name>_count`, `_avg_ms`, `_min_ms`, `_max_ms`. Therefore this PR is purely additive: wrap the body of `update_navigation_state` in a `time.perf_counter()` measurement and record the duration under the timer name `navigation_tick_duration`. No new abstractions, no new endpoints, no new dependencies. The metric becomes a visible Prometheus-compatible series the moment the navigation tick fires.
+
+**Tech Stack:** Python 3.11, existing `observability.metrics.record_timer` API, pytest, pytest-asyncio. No new dependencies.
+
+**Out of scope for this plan:**
+
+- CPU-time measurement (`psutil.Process().cpu_times()`) — wall time is what the handoff explicitly asked for; CPU time is a follow-up if/when we hit Pi thermal issues.
+- Recording metrics for `go_to_waypoint` (the 5 Hz mission control loop) — separate concern; the handoff says "navigation tick", which is the periodic `update_navigation_state` called from telemetry.
+- Adding histograms, percentiles, or per-component decomposition — `record_timer` already exposes count/avg/min/max which is enough for a baseline.
+- Wiring a per-phase budget regression check (the plan §12 second deliverable) — that needs the baseline number first; comes in a follow-up PR.
+- Event-persistence IO budget (§9) — separate change.
+- Backfilling timers for other services (telemetry, robohat, blade) — out of scope.
+
+---
+
+## File Structure
+
+**Created:**
+
+- `docs/runtime-budget.md` — short operator/dev doc explaining what the metric measures, where to read it, and how to capture a baseline. ≤80 lines.
+- `tests/contract/test_navigation_tick_metric.py` — contract test that the timer surfaces on `/metrics` after a tick. ≤40 lines.
+
+**Modified:**
+
+- `backend/src/services/navigation_service.py:1162` — wrap the body of `update_navigation_state` in a `time.perf_counter()` measurement and call `observability.metrics.record_timer("navigation_tick_duration", duration_ms)` in a `finally` block.
+- `tests/unit/test_navigation_service.py` — add one unit test asserting the timer increments after a tick.
+
+---
+
+## Task 1: Instrument `update_navigation_state` with the timer
+
+**Files:**
+
+- Modify: `backend/src/services/navigation_service.py:1162`
+- Test: `tests/unit/test_navigation_service.py`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Append to `tests/unit/test_navigation_service.py` (after the existing imports add `from backend.src.core.observability import observability` if not already present):
+
+```python
+@pytest.mark.asyncio
+async def test_update_navigation_state_records_tick_duration_metric():
+    observability.reset_events_for_testing()
+    nav = NavigationService()
+
+    await nav.update_navigation_state(
+        SensorData(gps=GpsReading(latitude=1.0, longitude=1.0, accuracy=0.5))
+    )
+
+    snapshot = observability.get_metrics_snapshot()
+    timer = snapshot["timers"].get("navigation_tick_duration")
+    assert timer is not None, "navigation_tick_duration timer should be recorded"
+    assert timer["count"] == 1
+    assert timer["avg"] >= 0.0
+    assert timer["min"] >= 0.0
+    assert timer["max"] >= timer["min"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `SIM_MODE=1 uv run pytest tests/unit/test_navigation_service.py::test_update_navigation_state_records_tick_duration_metric -v`
+Expected: FAIL with `AssertionError: navigation_tick_duration timer should be recorded` (the snapshot's `timers` map has no `navigation_tick_duration` key yet).
+
+- [ ] **Step 3: Implement the timer instrumentation**
+
+Edit `backend/src/services/navigation_service.py` around line 1162. The existing method signature is:
+
+```python
+async def update_navigation_state(self, sensor_data: SensorData) -> NavigationState:
+    """Update navigation state with sensor fusion"""
+
+    # Update position from GPS or dead reckoning
+    current_position = await self._update_position(sensor_data)
+    ...
+    return self.navigation_state
+```
+
+Wrap the body so the duration is always recorded, even if the body raises. The minimal patch:
+
+1. At the top of the file, ensure `from ..core.observability import observability` is imported (check existing imports first; the file already imports from `..core` for other things).
+2. Refactor the public method into a thin wrapper that times an inner implementation. The simplest non-invasive pattern is:
+
+```python
+async def update_navigation_state(self, sensor_data: SensorData) -> NavigationState:
+    """Update navigation state with sensor fusion."""
+    start = time.perf_counter()
+    try:
+        return await self._update_navigation_state_impl(sensor_data)
+    finally:
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        observability.metrics.record_timer("navigation_tick_duration", duration_ms)
+
+async def _update_navigation_state_impl(self, sensor_data: SensorData) -> NavigationState:
+    """Original update_navigation_state body — measured by the public wrapper."""
+    # ... existing body unchanged ...
+```
+
+`time` is already imported at the top of the file (`import time`). `observability` may not be — add the import alongside the other `..core` imports near the top of the file.
+
+When renaming the body, **do not change any internal logic**. Just rename `update_navigation_state` to `_update_navigation_state_impl` and add the new public wrapper above it. Existing internal calls within the file (e.g. `self.update_navigation_state(...)` from `_run_bootstrap_and_check_geofence` at line 944) continue to use the public wrapper, which is correct — bootstrap ticks should also be measured.
+
+- [ ] **Step 4: Run the new test to verify it passes**
+
+Run: `SIM_MODE=1 uv run pytest tests/unit/test_navigation_service.py::test_update_navigation_state_records_tick_duration_metric -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full navigation service test file**
+
+Run: `SIM_MODE=1 uv run pytest tests/unit/test_navigation_service.py tests/unit/test_navigation_service_capture.py -v`
+Expected: All previously-passing tests still pass. The pre-existing `xfail` marker on `test_go_to_waypoint_holds_until_fresh_gps_fix` is unchanged. No new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/services/navigation_service.py tests/unit/test_navigation_service.py
+git commit -m "feat(observability): record navigation tick wall-time as timer metric
+
+Wrap NavigationService.update_navigation_state in a time.perf_counter()
+measurement and record duration_ms via observability.metrics.record_timer
+under the name navigation_tick_duration. Establishes the baseline runtime
+metric required by §12 of the architecture plan."
+```
+
+---
+
+## Task 2: Contract test that the metric surfaces on `/metrics`
+
+**Files:**
+
+- Create: `tests/contract/test_navigation_tick_metric.py`
+
+- [ ] **Step 1: Write the failing contract test**
+
+Create `tests/contract/test_navigation_tick_metric.py`:
+
+```python
+"""Contract: the navigation tick wall-time metric is exposed on /metrics."""
+
+import pytest
+
+from backend.src.api.metrics import metrics
+from backend.src.core.observability import observability
+from backend.src.models import GpsReading, SensorData
+from backend.src.services.navigation_service import NavigationService
+
+
+@pytest.mark.asyncio
+async def test_navigation_tick_duration_appears_in_metrics_endpoint():
+    observability.reset_events_for_testing()
+    nav = NavigationService()
+    await nav.update_navigation_state(
+        SensorData(gps=GpsReading(latitude=1.0, longitude=1.0, accuracy=0.5))
+    )
+
+    body = metrics().body.decode()
+
+    assert "lawnberry_timer_navigation_tick_duration_count 1" in body
+    assert "lawnberry_timer_navigation_tick_duration_avg_ms" in body
+    assert "lawnberry_timer_navigation_tick_duration_min_ms" in body
+    assert "lawnberry_timer_navigation_tick_duration_max_ms" in body
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `SIM_MODE=1 uv run pytest tests/contract/test_navigation_tick_metric.py -v`
+Expected: PASS. Task 1's instrumentation already records the timer; this test just verifies the existing `/metrics` serializer renders it correctly. No production code change needed in this task — the test exists to lock the contract so future refactors of `metrics.py` don't accidentally drop the navigation tick output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/contract/test_navigation_tick_metric.py
+git commit -m "test(contract): lock navigation_tick_duration on /metrics endpoint
+
+Verifies the timer recorded by NavigationService.update_navigation_state
+surfaces on the Prometheus-compatible /metrics endpoint with the expected
+lawnberry_timer_navigation_tick_duration_{count,avg_ms,min_ms,max_ms}
+series names."
+```
+
+---
+
+## Task 3: Document the runtime budget metric
+
+**Files:**
+
+- Create: `docs/runtime-budget.md`
+
+- [ ] **Step 1: Write the doc**
+
+Create `docs/runtime-budget.md` with the following content (no placeholders — this is the final text):
+
+````markdown
+# Runtime Budget — Navigation Tick
+
+This document tracks the runtime cost of the navigation tick (`NavigationService.update_navigation_state`) so we can detect regressions as the architecture plan progresses (§3 real-pose pipeline, §1 RuntimeContext follow-ups, §9 event persistence).
+
+The metric is the first deliverable of §12 ("Power, Thermal, and Runtime Budget") in `docs/major-architecture-and-code-improvement-plan.md`.
+
+## What is measured
+
+- **Series name:** `lawnberry_timer_navigation_tick_duration` (Prometheus-compatible).
+- **Sub-series:** `_count` (number of ticks), `_avg_ms`, `_min_ms`, `_max_ms`.
+- **Unit:** milliseconds of wall-clock time per call.
+- **Scope:** entire body of `NavigationService.update_navigation_state` — pose update from GPS/dead-reckoning, heading fusion (IMU + GPS COG), obstacle detection, navigation-state mutation. Does not include `set_speed` or motor command delivery (those are outside the tick).
+
+## How to read the current value
+
+Run the backend and curl the metrics endpoint:
+
+```bash
+curl -s http://localhost:8000/metrics | grep navigation_tick_duration
+```
+
+Expected output shape:
+
+```text
+lawnberry_timer_navigation_tick_duration_count 1234
+lawnberry_timer_navigation_tick_duration_avg_ms 4.21
+lawnberry_timer_navigation_tick_duration_min_ms 0.83
+lawnberry_timer_navigation_tick_duration_max_ms 18.07
+```
+
+## How to capture a baseline
+
+A baseline pair `(avg_ms, max_ms)` should be captured on the target Pi 5 platform before each major architecture change, and committed to this doc with the date and HEAD SHA.
+
+1. Boot the mower in `SIM_MODE=0` (real hardware) with a typical mission running.
+2. Let the mission run for **at least 5 minutes** so the timer averages stabilize across waypoints, tank turns, and obstacle events.
+3. Capture the metric once: `curl -s http://localhost:8000/metrics | grep navigation_tick_duration`.
+4. Append a row to the baseline table below.
+
+## Baseline history
+
+| Date | HEAD SHA | Conditions | count | avg_ms | min_ms | max_ms | Notes |
+|------|----------|------------|-------|--------|--------|--------|-------|
+| _TBD — first capture pending operator yard run_ | | | | | | | Captured before §3 real-pose pipeline |
+
+## Regression policy
+
+- A change that increases `avg_ms` by more than 50% over the previous baseline must justify the cost in the PR description.
+- A change that increases `max_ms` by more than 100% (a new tail latency spike) must include a follow-up issue or a mitigation note in the same PR.
+- These thresholds are intentionally loose for the first two captured baselines while we learn the variance of the metric on real hardware. Tighten in a follow-up once we have ≥3 baseline rows.
+
+## Related code
+
+- Instrumentation: `backend/src/services/navigation_service.py` — the `update_navigation_state` wrapper.
+- Endpoint: `backend/src/api/metrics.py` — Prometheus-compatible serializer.
+- Plan reference: `docs/major-architecture-and-code-improvement-plan.md` §12.
+````
+
+- [ ] **Step 2: Verify the doc renders**
+
+Run: `cat docs/runtime-budget.md | head -10`
+Expected: file exists and shows the heading line `# Runtime Budget — Navigation Tick`. No tooling validation required (no docs lint in CI for non-spec markdown).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/runtime-budget.md
+git commit -m "docs(observability): document navigation tick runtime budget metric
+
+Adds docs/runtime-budget.md with the metric definition, how to read it
+from /metrics, the procedure for capturing a baseline on real hardware,
+and the regression policy. First baseline row is left as TBD pending an
+operator yard run."
+```
+
+---
+
+## Verification before PR
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `SIM_MODE=1 uv run pytest -q`
+Expected: same pass/skip/xfail counts as the handoff baseline (600 passed, 47 skipped, 12 xfailed, 2 xpassed) **plus 2 new passes** from this PR (`test_update_navigation_state_records_tick_duration_metric` and `test_navigation_tick_duration_appears_in_metrics_endpoint`). Total: 602 passed, 47 skipped, 12 xfailed, 2 xpassed.
+
+- [ ] **Step 2: Run lint**
+
+Run: `uv run ruff check backend/src/services/navigation_service.py tests/unit/test_navigation_service.py tests/contract/test_navigation_tick_metric.py`
+Expected: 0 errors. The repo pins `ruff==0.13.3` (per `.github/workflows/ci.yml`).
+
+- [ ] **Step 3: Open the PR**
+
+Push the branch and open a PR titled `feat(observability): baseline navigation tick runtime metric (§12)`. Body should reference this plan doc and the §12 section of the architecture plan, and call out that the first baseline-table row is left as TBD pending an operator yard run.

--- a/tests/contract/test_navigation_tick_metric.py
+++ b/tests/contract/test_navigation_tick_metric.py
@@ -1,0 +1,25 @@
+"""Contract: the navigation tick wall-time metric is exposed on /metrics."""
+
+import pytest
+
+from backend.src.api.metrics import metrics
+from backend.src.core.observability import observability
+from backend.src.models import GpsReading, SensorData
+from backend.src.services.navigation_service import NavigationService
+
+
+@pytest.mark.asyncio
+async def test_navigation_tick_duration_appears_in_metrics_endpoint():
+    observability.reset_events_for_testing()
+    nav = NavigationService()
+
+    await nav.update_navigation_state(
+        SensorData(gps=GpsReading(latitude=1.0, longitude=1.0, accuracy=0.5))
+    )
+
+    body = metrics().body.decode()
+
+    assert "lawnberry_timer_navigation_tick_duration_count 1" in body
+    assert "lawnberry_timer_navigation_tick_duration_avg_ms" in body
+    assert "lawnberry_timer_navigation_tick_duration_min_ms" in body
+    assert "lawnberry_timer_navigation_tick_duration_max_ms" in body

--- a/tests/unit/test_navigation_service.py
+++ b/tests/unit/test_navigation_service.py
@@ -5,6 +5,7 @@ import pytest
 
 import backend.src.services.mission_service as mission_service_module
 import backend.src.services.navigation_service as navigation_service_module
+from backend.src.core.observability import observability
 from backend.src.core.state_manager import AppState, set_sensor_manager
 from backend.src.models import (
     GpsReading,
@@ -672,3 +673,21 @@ async def test_blended_mode_right_turn_left_speed_greater_than_right(monkeypatch
     assert first_left > first_right, (
         f"Blended CW turn: left ({first_left:.3f}) must be > right ({first_right:.3f})"
     )
+
+
+@pytest.mark.asyncio
+async def test_update_navigation_state_records_tick_duration_metric():
+    observability.reset_events_for_testing()
+    nav = NavigationService()
+
+    await nav.update_navigation_state(
+        SensorData(gps=GpsReading(latitude=1.0, longitude=1.0, accuracy=0.5))
+    )
+
+    snapshot = observability.get_metrics_snapshot()
+    timer = snapshot["timers"].get("navigation_tick_duration")
+    assert timer is not None, "navigation_tick_duration timer should be recorded"
+    assert timer["count"] == 1
+    assert timer["avg"] >= 0.0
+    assert timer["min"] >= 0.0
+    assert timer["max"] >= timer["min"]


### PR DESCRIPTION
## Summary

- Instruments `NavigationService.update_navigation_state` with a `time.perf_counter()` wall-time measurement and records it via `observability.metrics.record_timer("navigation_tick_duration", duration_ms)`.
- The existing `/metrics` endpoint already serializes timers as Prometheus-compatible series, so this PR is purely additive — `lawnberry_timer_navigation_tick_duration_{count,avg_ms,min_ms,max_ms}` shows up immediately once a tick fires.
- Adds `docs/runtime-budget.md` with the metric definition, how to read it, the procedure for capturing a baseline on real hardware, and the regression policy. The first baseline-table row is left as TBD pending an operator yard run (this dev box can't produce a hardware baseline).

Implements the first deliverable of §12 ("Power, Thermal, and Runtime Budget") in `docs/major-architecture-and-code-improvement-plan.md`. Plan doc: `docs/superpowers/plans/2026-04-29-navigation-tick-metric.md`.

Out of scope (intentional): CPU-time measurement, `go_to_waypoint` 5 Hz loop, per-phase budget regression check, event-persistence IO budget, and timers for other services. Each is a separate follow-up.

## Test plan

- [x] `SIM_MODE=1 uv run pytest -q` → 619 passed, 47 skipped, 11 xfailed, 3 xpassed, 0 failed (locally, fresh run).
- [x] `uv run ruff check backend/src/services/navigation_service.py tests/contract/test_navigation_tick_metric.py` → All checks passed (the 5 pre-existing ruff errors in `tests/unit/test_navigation_service.py` are not introduced by this PR; CI lint scope is `backend/src` only).
- [x] New unit test: `tests/unit/test_navigation_service.py::test_update_navigation_state_records_tick_duration_metric` — exercises the timer is recorded after one tick.
- [x] New contract test: `tests/contract/test_navigation_tick_metric.py::test_navigation_tick_duration_appears_in_metrics_endpoint` — locks the four `lawnberry_timer_navigation_tick_duration_*` series on the `/metrics` endpoint.
- [ ] First real baseline row in `docs/runtime-budget.md` — requires an operator yard run; deferred per the handoff doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)