### PR TITLE
feat(control): Phase C — nav/mission services migrate to gateway

### DIFF
--- a/backend/src/services/mission_service.py
+++ b/backend/src/services/mission_service.py
@@ -25,6 +25,24 @@ from ..services.navigation_service import NavigationService
 logger = logging.getLogger(__name__)
 
 
+def _is_emergency_active() -> bool:
+    """Check emergency state via gateway if available, else direct dict read."""
+    try:
+        from ..main import app
+
+        gw = getattr(getattr(app.state, "runtime", None), "command_gateway", None)
+        if gw is not None:
+            return gw.is_emergency_active()
+    except Exception:
+        pass
+    try:
+        from ..core import globals as _g
+
+        return bool(_g._safety_state.get("emergency_stop_active", False))
+    except Exception:
+        return False
+
+
 class MissionError(Exception):
     """Base mission domain error."""
 
@@ -364,10 +382,9 @@ class MissionService:
     async def start_mission(self, mission_id: str):
         import os
 
-        from ..api import rest as rest_api
         from .robohat_service import get_robohat_service
 
-        if rest_api._safety_state.get("emergency_stop_active", False):
+        if _is_emergency_active():
             raise MissionStateError("Cannot start mission while emergency stop is active.")
 
         # Pre-flight: verify motor controller is available (skip in simulation)
@@ -504,10 +521,9 @@ class MissionService:
     async def resume_mission(self, mission_id: str):
         import os
 
-        from ..api import rest as rest_api
         from .robohat_service import get_robohat_service
 
-        if rest_api._safety_state.get("emergency_stop_active", False):
+        if _is_emergency_active():
             raise MissionStateError("Cannot resume mission while emergency stop is active.")
 
         # Pre-flight: verify motor controller is available (skip in simulation)

--- a/backend/src/services/navigation_service.py
+++ b/backend/src/services/navigation_service.py
@@ -1036,14 +1036,22 @@ class NavigationService:
         """Return True when the API-level emergency stop is latched OR any active
         hardware safety interlock (tilt, obstacle, geofence, etc.) is present.
 
-        Previously only checked rest_api._safety_state which is only set by the
-        explicit /emergency-stop endpoint — hardware interlocks activated by
-        SafetyTriggerManager never reached this check (ARCH-001).
+        Prefer the gateway if available (Phase C+); fall back to direct state read.
         """
         try:
-            from ..api import rest as rest_api
+            from ..main import app
 
-            if rest_api._safety_state.get("emergency_stop_active", False):
+            gw = getattr(getattr(app.state, "runtime", None), "command_gateway", None)
+            if gw is not None:
+                return gw.is_emergency_active()
+        except Exception:
+            pass
+
+        # Legacy fallback: read the shared dict directly (same dict the gateway holds)
+        try:
+            from ..core import globals as _g
+
+            if _g._safety_state.get("emergency_stop_active", False):
                 return True
         except Exception:
             pass
@@ -1065,15 +1073,33 @@ class NavigationService:
     def _latch_global_emergency_state(self) -> None:
         """Mirror the control API emergency latch for non-HTTP emergency paths."""
         try:
-            from ..api import rest as rest_api
+            from ..control.commands import EmergencyTrigger
+            from ..main import app
 
-            rest_api._safety_state["emergency_stop_active"] = True
-            rest_api._blade_state["active"] = False
-            rest_api._legacy_motors_active = False
-            rest_api._emergency_until = time.time() + 0.2
+            gw = getattr(getattr(app.state, "runtime", None), "command_gateway", None)
+            if gw is not None:
+                import asyncio
+
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    asyncio.ensure_future(
+                        gw.trigger_emergency(
+                            EmergencyTrigger(reason="Navigation safety trigger", source="navigation")
+                        )
+                    )
+                    return
+        except Exception:
+            pass
+
+        # Legacy fallback when gateway unavailable (unit tests, early startup)
+        try:
+            from ..core import globals as _g
+
+            _g._safety_state["emergency_stop_active"] = True
+            _g._blade_state["active"] = False
         except Exception:
             logger.debug(
-                "Unable to mirror global emergency state from navigation service", exc_info=True
+                "Unable to latch emergency state from navigation service", exc_info=True
             )
 
     @staticmethod
@@ -1741,9 +1767,9 @@ class NavigationService:
 
         # Record reason so the UI can show why the e-stop was activated
         try:
-            import backend.src.api.rest as rest_api
+            from ..core import globals as _g
 
-            rest_api._safety_state["estop_reason"] = reason
+            _g._safety_state["estop_reason"] = reason
         except Exception:
             pass
 

--- a/tests/integration/test_safety_router_runtime.py
+++ b/tests/integration/test_safety_router_runtime.py
@@ -89,3 +89,34 @@ def test_safety_endpoints_do_not_import_globals_from_rest():
         "safety.py still imports _safety_state or _blade_state from rest.py "
         "in some import form"
     )
+
+
+def test_navigation_service_does_not_import_state_from_rest():
+    """navigation_service.py must not read/write rest_api._safety_state after Phase C."""
+    import re
+
+    from backend.src.services import navigation_service
+
+    text = open(navigation_service.__file__).read()
+    bad_patterns = [
+        r"rest_api\._safety_state",
+        r"rest_api\._blade_state",
+        r"rest_api\._emergency_until",
+        r"rest_api\._legacy_motors_active",
+    ]
+    for pat in bad_patterns:
+        assert not re.search(pat, text), (
+            f"navigation_service.py still accesses {pat!r} from rest_api"
+        )
+
+
+def test_mission_service_does_not_import_state_from_rest():
+    """mission_service.py must not read rest_api._safety_state after Phase C."""
+    import re
+
+    from backend.src.services import mission_service
+
+    text = open(mission_service.__file__).read()
+    assert not re.search(r"rest_api\._safety_state", text), (
+        "mission_service.py still reads rest_api._safety_state"
+    )


### PR DESCRIPTION
## Summary
- `navigation_service.py`: `_global_emergency_active` and `_latch_global_emergency_state` route through gateway; fallback to `core.globals` when gateway unavailable (unit tests)
- `mission_service.py`: `_is_emergency_active()` helper replaces direct `rest_api._safety_state` reads
- Import-purity guards added to `test_safety_router_runtime.py`

## Test plan
- [ ] `SIM_MODE=1 uv run pytest -q` — 0 failures
- [ ] `SIM_MODE=1 uv run pytest tests/integration/test_safety_router_runtime.py -v` — all pass including new guards
- [ ] `SIM_MODE=1 uv run ruff check backend/src` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)